### PR TITLE
Set screenshot size according to video quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://addons.mozilla.org/en-US/developers/addon/youtube-screenshot-button/
 
 # Description
 * This add-on adds extra button on youtube player to download the screenshot of video.
-* Enjoy seamless experience from this very light weight add-on very.
+* Enjoy seamless experience from this very light weight add-on.
 * This addon is completely safe to use.
 * This is an open source project, find the code on https://github.com/gurumukhi/youtube-screenshot.
 


### PR DESCRIPTION
I tried to address issue #1 with this PR as I was not able to capture a 2160px picture even after selecting 2160p quality in YouTube current video settings.
It seems the add-on currently use the video viewport size. Using selected quality may to create the screenshot may produce a bigger or smaller picture.