### PR TITLE
Fix addon initialization error when starting by YouTube homepage

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -65,24 +65,15 @@ logger = function (message) {
   }
 };
 
-init = function () {
-  if (initCalled) {
-    console.log("NOT SETTING");
-    return;
+// Initialization
+console.log("Initializing Youtube Screenshot Addon");
+
+var storageItem = browser.storage.local.get();
+storageItem.then((result) => {
+  if (result.YouTubeScreenshotAddonisDebugModeOn) {
+    logger("Addon initializing!");
+    loggingEnabled = true;
   }
-
-  console.log("SETTING");
-  initCalled = true;
-  // Initialization
-  var storageItem = browser.storage.local.get();
-  storageItem.then((result) => {
-    if (result.YouTubeScreenshotAddonisDebugModeOn) {
-      logger("Addon initializing!");
-      loggingEnabled = true;
-    }
-    addButtonOnYoutubePlayer();
-    addEventListener();
-  });
-};
-
-init();
+  addButtonOnYoutubePlayer();
+  addEventListener();
+});

--- a/content_script.js
+++ b/content_script.js
@@ -39,17 +39,16 @@ getFileName = function () {
   return `${window.document.title} - ${mm}:${ss}.jpeg`;
 };
 
-addButtonOnYoutubePlayer = function () {
+addButtonOnYoutubePlayer = function (controlsDiv) {
   logger("Adding screenshot button");
-  var btn = document.createElement("button");
-  var t = document.createTextNode("Screenshot");
+  let btn = document.createElement("button");
+  let t = document.createTextNode("Screenshot");
   btn.classList.add("ytp-time-display");
   btn.classList.add("ytp-button");
   btn.classList.add("ytp-screenshot");
   btn.style.width = "auto";
   btn.appendChild(t);
-  var youtubeRightButtonsDiv = document.querySelector(".ytp-right-controls");
-  youtubeRightButtonsDiv.insertBefore(btn, youtubeRightButtonsDiv.firstChild);
+  controlsDiv.insertBefore(btn, controlsDiv.firstChild);
 };
 
 addEventListener = function () {
@@ -58,6 +57,36 @@ addEventListener = function () {
   youtubeScreenshotButton.removeEventListener("click", captureScreenshot);
   youtubeScreenshotButton.addEventListener("click", captureScreenshot);
 };
+
+function waitForYoutubeControls(callback) {
+  const controlsClass = "ytp-right-controls";
+
+  const controlsDiv = document.querySelector(`.${controlsClass}`);
+  if (controlsDiv) {
+    callback(controlsDiv);
+    return;
+  }
+
+  // Controls are not yet ready, wait for them
+  logger("Wait for Youtube controls");
+
+  let observer = new MutationObserver((mutations) => {
+    mutations.forEach(mutation => {
+      if (!mutation.addedNodes)
+        return;
+
+      for (let element of mutation.addedNodes) {
+        if (element.classList.contains(controlsClass)) {
+          observer.disconnect();
+          logger("Found Youtube controls");
+          callback(element);
+        }
+      }
+    })
+  })
+
+  observer.observe(document.body, { childList: true, subtree: true });
+}
 
 logger = function (message) {
   if (loggingEnabled) {
@@ -74,6 +103,9 @@ storageItem.then((result) => {
     logger("Addon initializing!");
     loggingEnabled = true;
   }
-  addButtonOnYoutubePlayer();
-  addEventListener();
+
+  waitForYoutubeControls(controlsDiv => {
+    addButtonOnYoutubePlayer(controlsDiv);
+    addEventListener();
+  });
 });


### PR DESCRIPTION
Manage controls div may not exist yet in DOM when content script is loaded. Use MutationObserver to monitor DOM and add screenshot button when controls are ready.

By the way, the first commit of this PR addresses issue #19 removing unneeded call once guard in initialization.