### PR TITLE
Set screenshot size according to video size

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ https://addons.mozilla.org/en-US/developers/addon/youtube-screenshot-button/
 
 # Description
 * This add-on adds extra button on youtube player to download the screenshot of video.
-* Enjoy seamless experience from this very light weight add-on very.
+* Enjoy seamless experience from this very light weight add-on.
 * This addon is completely safe to use.
 * This is an open source project, find the code on https://github.com/gurumukhi/youtube-screenshot.
 

--- a/content_script.js
+++ b/content_script.js
@@ -7,8 +7,8 @@ captureScreenshot = function () {
   var canvas = document.createElement("canvas");
   var video = document.querySelector("video");
   var ctx = canvas.getContext("2d");
-  canvas.width = parseInt(video.style.width);
-  canvas.height = parseInt(video.style.height);
+  canvas.width = parseInt(video.videoWidth);
+  canvas.height = parseInt(video.videoHeight);
   ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
   downloadFile(canvas);
 };


### PR DESCRIPTION
Using video viewport size to create the screenshot limits the exported quality. Directly used video size to set the corresponding canvas size.

Replaces PR #17 and should fix issue #1.