### PR TITLE
Add an option to copy screenshot to clipboard

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,0 +1,21 @@
+browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.cmd === "copyToClipboard") {
+    message.data.arrayBuffer()
+      .then((data) => {
+          browser.clipboard.setImageData(data, "png")
+          .then(() => {
+            sendResponse();
+
+            browser.notifications.create({
+              type: "basic",
+              title: "Youtube Screenshot",
+              message: "Screenshot successfully copied to clipboard.",
+            });
+          })
+        .catch((e) => sendResponse(e));
+      })
+      .catch((e) => sendResponse(e));
+
+    return true;
+  }
+});

--- a/content_script.js
+++ b/content_script.js
@@ -1,5 +1,4 @@
 var loggingEnabled = false;
-var initCalled = false;
 
 // Image format
 var imageFormat = "image/jpeg";

--- a/content_script.js
+++ b/content_script.js
@@ -10,8 +10,8 @@ captureScreenshot = function () {
   var canvas = document.createElement("canvas");
   var video = document.querySelector("video");
   var ctx = canvas.getContext("2d");
-  canvas.width = parseInt(video.videoWidth);
-  canvas.height = parseInt(video.videoHeight);
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
   ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
   downloadFile(canvas);
 };

--- a/content_script.js
+++ b/content_script.js
@@ -18,14 +18,14 @@ captureScreenshot = function () {
   if (copyToClipboardEnabled)
     copyToClipboard(canvas);
   else
-    downloadFile(canvas);
+    downloadFile(canvas, video);
 };
 
-downloadFile = function (canvas) {
+downloadFile = function (canvas, video) {
   var aClass = "youtube-screenshot-a";
   var a = document.createElement("a");
   a.href = canvas.toDataURL(imageFormat);
-  a.download = getFileName();
+  a.download = getFileName(video);
   a.style.display = "none";
   a.classList.add(aClass);
   document.body.appendChild(a);
@@ -49,8 +49,8 @@ function copyToClipboard(canvas) {
     }, "image/png");
 }
 
-getFileName = function () {
-  seconds = document.getElementsByClassName("video-stream")[0].currentTime;
+getFileName = function (video) {
+  seconds = video.currentTime;
   mins = seconds / 60;
   secs = seconds % 60;
   m = mins.toString();

--- a/manifest.json
+++ b/manifest.json
@@ -12,8 +12,12 @@
       "js": ["content_script.js"]
     }
   ],
+  "background": {
+    "scripts": ["background.js"],
+    "persistent": false
+  },
   "options_ui": {
     "page": "options/index.html"
   },
-  "permissions": ["storage"]
+  "permissions": ["storage", "clipboardWrite", "notifications"]
 }

--- a/options/index.html
+++ b/options/index.html
@@ -6,18 +6,29 @@
   </head>
   <body>
     <div class="form">
-      <label>Debug mode (for verbose logging in browser console): </label>
-      <input type="radio" name="debugMode" value="debugOn"> On &nbsp; &nbsp;
-      <input type="radio" name="debugMode" value="debugOff"> Off &nbsp; &nbsp;&nbsp; &nbsp;
-      <br/>
-      <label>Screenshot format: </label>
-      <select name="format">
-      <option value="jpeg">JPEG</option>
-      <option value="png">PNG</option>
-      </select>
-      <br/>
+      <div id="debug">
+        <label>Debug mode (for verbose logging in browser console): </label>
+        <input type="radio" name="debugMode" value="debugOn"> On &nbsp; &nbsp;
+        <input type="radio" name="debugMode" value="debugOff"> Off &nbsp; &nbsp;&nbsp; &nbsp;
+      </div>
+
+      <div id="action">
+        <label>Screenshot button action: </label>
+        <select name="action">
+          <option value="file">Download file</option>
+          <option value="clipboard">Copy to clipboard</option>
+        </select>
+      </div>
+
+      <div id="format">
+        <label>Screenshot format: </label>
+        <select name="format">
+          <option value="jpeg">JPEG</option>
+          <option value="png">PNG</option>
+        </select>
+      </div>
+
       <button id="save">Save</button>
-      <br/>
     </div>
     <script src="script.js"></script>
   </body>

--- a/options/script.js
+++ b/options/script.js
@@ -2,12 +2,19 @@ function saveOptions(e) {
     browser.storage.local.set({
         YouTubeScreenshotAddonisDebugModeOn: document.querySelector('input[name=debugMode]:checked') &&
                     document.querySelector('input[name=debugMode]:checked').value === 'debugOn',
+        screenshotAction: document.querySelector('select[name=action]').value,
         imageFormat: document.querySelector('select[name=format]').value,
     });
     e.preventDefault();
 }
 
 function restoreOptions() {
+    document.querySelector("select[name=action]").addEventListener("change", (event) => {
+        console.log(event);
+        document.querySelector('div#format').hidden =
+            document.querySelector('option[value=clipboard]').selected;
+    });
+
     var storageItem = browser.storage.local.get();
     storageItem.then((value) => {
         console.log(value);
@@ -15,6 +22,12 @@ function restoreOptions() {
             document.querySelector('input[value=debugOn]').checked = true;
         } else {
             document.querySelector('input[value=debugOff]').checked = true;
+        }
+
+        if (value.screenshotAction === "clipboard") {
+            console.log(document.querySelector('#format'));
+            document.querySelector('option[value=clipboard]').selected = true;
+            document.querySelector('#format').hidden = true;
         }
 
         if (value.imageFormat === "png")

--- a/options/style.css
+++ b/options/style.css
@@ -1,3 +1,7 @@
 .form {
   width: 100%;
 }
+
+.form div {
+  margin-bottom: 5px;
+}


### PR DESCRIPTION
Use a background script companion to access clipboard.
Note the selected API `browser.clipboard.setImageData()` is only supported by Firefox.
Also add a notification to indicate copy success.

Linked to issue #8.
