### PR TITLE
Add a check to avoid duplicating screenshot button

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -44,6 +44,13 @@ getFileName = function () {
 };
 
 addButtonOnYoutubePlayer = function (controlsDiv) {
+  // Check if button already present
+  let previousBtn = document.querySelector("button.ytp-screenshot");
+  if (previousBtn) {
+    logger("Removing previous screenshot button");
+    previousBtn.remove();
+  }
+
   logger("Adding screenshot button");
   let btn = document.createElement("button");
   let t = document.createTextNode("Screenshot");


### PR DESCRIPTION
Such a duplicate could appear if disabling / enabling the addon from Firefox addon page, or reloading from the debugging one. The patch simply removes the element from DOM if already existing before adding a fresh new one.

It should fix issue revealed by @gurumukhi in PR #22.