### PR TITLE
Fix unclickable screenshot button on YouTube shorts

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -117,6 +117,9 @@ function addButtonOnPlayer(container, regularNotShorts) {
     btn.style.border = "none";
     btn.style.cursor = "pointer";
     btn.style.background = "none";
+
+    // Ensure the pointer event are not disabled for our custom button
+    btn.style.pointerEvents = "all";
   }
 
   btn.classList.add(btnClass);


### PR DESCRIPTION
Next to a YouTube interface change, custom "Screenshot" button on YouTube shorts was not clickable anymore.
Force the "pointer-events" CSS property to "all" to still catch the click event as this property is in fact set to "none" in a parent node now.

It should fix issue #43.