### PR TITLE
Hot reload configuration

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,27 +1,24 @@
-browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.cmd === "copyToClipboard") {
-    message.data.arrayBuffer()
-      .then((data) => {
-          browser.clipboard.setImageData(data, "png")
-          .then(() => {
-            sendResponse();
+function showNotification(message) {
+  browser.notifications.create({
+    type: "basic",
+    title: "Youtube Screenshot",
+    message: message,
+  });
+}
 
-            browser.notifications.create({
-              type: "basic",
-              title: "Youtube Screenshot",
-              message: "Screenshot successfully copied to clipboard.",
-            });
-          })
-        .catch((e) => sendResponse(e));
-      })
-      .catch((e) => sendResponse(e));
+async function copyToClipboard(data) {
+  let buffer = await data.arrayBuffer();
+  await browser.clipboard.setImageData(buffer, "png");
+  showNotification("Screenshot successfully copied to clipboard.");
+}
 
-    return true;
-  } else if (message.cmd === "showProtectionError") {
-    browser.notifications.create({
-      type: "basic",
-      title: "Youtube Screenshot",
-      message: "Cannot screenshot DRM-protected content.",
-    });
+browser.runtime.onMessage.addListener(request => {
+  if (request.cmd === "copyToClipboard") {
+    copyToClipboard(request.data)
+      .then(() => { return Promise.resolve({}); })
+      .catch((e) => { return Promise.resolve(e); });
+  } else if (request.cmd === "showProtectionError") {
+    showNotification("Cannot screenshot DRM-protected content.");
+    return Promise.resolve({});
   }
 });

--- a/content_script.js
+++ b/content_script.js
@@ -15,6 +15,8 @@ let currentConfiguration = {
   // Image format
   imageFormat: "image/jpeg",
   imageFormatExtension: "jpeg",
+
+  shortcutEnabled: true,
 };
 
 // Shorts container tag and active attribute
@@ -241,6 +243,11 @@ async function loadConfiguration() {
     logger = logNull;
   }
 
+  // Shortcut
+  currentConfiguration.shortcutEnabled = result.shortcutEnabled ?? true;
+  logger(`${currentConfiguration.shortcutEnabled ? "Enabling" : "Disabling"} screenshot shortcut`);
+
+  // Button action and image format
   if (result.screenshotAction === "clipboard") {
     currentConfiguration.copyToClipboard = true;
   } else {
@@ -280,4 +287,36 @@ browser.runtime.onMessage.addListener(request => {
     loadConfiguration();
 
   return Promise.resolve({});
+});
+
+// Handle shortcut
+document.addEventListener('keydown', e => {
+  if (!currentConfiguration.shortcutEnabled) {
+    logger("Shortcut is disabled");
+    return;
+  }
+
+  const tagName = e.target.tagName;
+  if (e.target.isContentEditable
+      || (tagName === "INPUT")
+      || (tagName === "SELECT")
+      || (tagName === "TEXTAREA")) {
+      return;
+    }
+
+  if (!e.shiftKey)
+    return;
+
+  if ((e.key === 'a') || (e.key === 'A')) {
+    logger("Catching screenshot shortcut");
+
+    // Simply search for the screenshot button and simulate click
+    let btn = document.querySelector("button.ytp-screenshot")
+              || document.querySelector("button.ytd-screenshot");
+
+    if (btn) {
+      btn.click();
+      return;
+    }
+  }
 });

--- a/content_script.js
+++ b/content_script.js
@@ -224,11 +224,8 @@ function waitForControls(regularCallback, shortsCallback) {
   observer.observe(document.body, { childList: true, subtree: true });
 }
 
-// Initialization (logger is not yet really initialized for the moment)
-console.log("Initializing Youtube Screenshot Addon");
-
-let storageItem = browser.storage.local.get();
-storageItem.then((result) => {
+async function loadConfiguration() {
+  let result = await browser.storage.local.get();
   if (result.YouTubeScreenshotAddonisDebugModeOn) {
     logger = (message) => {
         console.log(`Youtube Screenshot Addon: ${message}`);
@@ -247,7 +244,12 @@ storageItem.then((result) => {
 
     logger(`Setting image format to: ${currentConfiguration.imageFormat}`);
   }
+}
 
+// Initialization (logger is not yet really initialized for the moment)
+console.log("Initializing Youtube Screenshot Addon");
+
+loadConfiguration().then(() => {
   waitForControls(
     (regularControls) => {
       addButtonOnPlayer(regularControls, true);

--- a/content_script.js
+++ b/content_script.js
@@ -3,11 +3,13 @@ let logger = (message) => {
   // Nothing
 };
 
-var copyToClipboardEnabled = false;
+let currentConfiguration = {
+  copyToClipboard: false,
 
-// Image format
-var imageFormat = "image/jpeg";
-var imageFormatExtension = "jpeg";
+  // Image format
+  imageFormat: "image/jpeg",
+  imageFormatExtension: "jpeg",
+};
 
 // Shorts container tag and active attribute
 const shortsContainerTag = "ytd-reel-video-renderer";
@@ -34,15 +36,15 @@ captureScreenshot = function () {
   canvas.height = parseInt(video.videoHeight);
   ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
 
-  if (copyToClipboardEnabled)
+  if (currentConfiguration.copyToClipboard)
     copyToClipboard(canvas);
   else
     downloadFile(canvas, video);
 };
 
-downloadFile = function (canvas, video) {
+function downloadFile(canvas, video) {
   let a = document.createElement("a");
-  a.href = canvas.toDataURL(imageFormat);
+  a.href = canvas.toDataURL(currentConfiguration.imageFormat);
   a.download = getFileName(video);
   a.style.display = "none";
   document.body.appendChild(a);
@@ -89,7 +91,7 @@ function getFileName(video) {
     timeString += `0-`+`${mins}-${s}`;
   }
 
-  return `${window.document.title} - ${timeString}.${imageFormatExtension}`;
+  return `${window.document.title} - ${timeString}.${currentConfiguration.imageFormatExtension}`;
 };
 
 function addButtonOnPlayer(container, regularNotShorts) {
@@ -236,14 +238,14 @@ storageItem.then((result) => {
   }
 
   if (result.screenshotAction === "clipboard") {
-    copyToClipboardEnabled = true;
+    currentConfiguration.copyToClipboard = true;
   } else {
     if (result.imageFormat === "png") {
-      imageFormat = "image/png";
-      imageFormatExtension = "png";
+      currentConfiguration.imageFormat = "image/png";
+      currentConfiguration.imageFormatExtension = "png";
     }
 
-    logger(`Setting image format to: ${imageFormat}`);
+    logger(`Setting image format to: ${currentConfiguration.imageFormat}`);
   }
 
   waitForControls(

--- a/options/index.html
+++ b/options/index.html
@@ -6,18 +6,6 @@
   </head>
   <body>
     <div class="form">
-      <fieldset id="debug">
-        <legend>Debug mode (for verbose logging in browser console)</legend>
-        <div>
-          <input type="radio" name="debugMode" value="debugOff" />
-          <label for="debugOff">Off</label>
-        </div>
-        <div>
-          <input type="radio" name="debugMode" value="debugOn" />
-          <label for="debugOn">On</label>
-        </div>
-      </fieldset>
-
       <fieldset id="action">
         <legend>Screenshot button action</legend>
         <div>
@@ -51,6 +39,18 @@
         <div>
           <input type="radio" name="shortcut" value="shortcutOn" />
           <label for="shortcutOn">On</label>
+        </div>
+      </fieldset>
+
+      <fieldset id="debug">
+        <legend>Debug mode (for verbose logging in browser console)</legend>
+        <div>
+          <input type="radio" name="debugMode" value="debugOff" />
+          <label for="debugOff">Off</label>
+        </div>
+        <div>
+          <input type="radio" name="debugMode" value="debugOn" />
+          <label for="debugOn">On</label>
         </div>
       </fieldset>
 

--- a/options/index.html
+++ b/options/index.html
@@ -42,6 +42,18 @@
         </div>
       </fieldset>
 
+      <fieldset id="shortcut">
+        <legend>Enable shortcut (Shift+A)</legend>
+        <div>
+          <input type="radio" name="shortcut" value="shortcutOff" />
+          <label for="shortcutOff">Off</label>
+        </div>
+        <div>
+          <input type="radio" name="shortcut" value="shortcutOn" />
+          <label for="shortcutOn">On</label>
+        </div>
+      </fieldset>
+
       <button id="save">Save</button>
     </div>
     <script src="script.js"></script>

--- a/options/index.html
+++ b/options/index.html
@@ -9,11 +9,11 @@
       <fieldset id="action">
         <legend>Screenshot button action</legend>
         <div>
-          <input type="radio" name="action" value="actionFile" />
+          <input type="radio" name="action" id="actionFile" value="actionFile" />
           <label for="actionFile">Download file</label>
         </div>
         <div>
-          <input type="radio" name="action" value="actionClipboard" />
+          <input type="radio" name="action" id="actionClipboard" value="actionClipboard" />
           <label for="actionClipboard">Copy to clipboard</label>
         </div>
       </fieldset>
@@ -21,11 +21,11 @@
       <fieldset id="format">
         <legend>Screenshot format</legend>
         <div>
-          <input type="radio" name="format" value="formatJpeg" />
+          <input type="radio" name="format" id="formatJpeg" value="formatJpeg" />
           <label for="formatJpeg">JPEG</label>
         </div>
         <div>
-          <input type="radio" name="format" value="formatPng" />
+          <input type="radio" name="format" id="formatPng" value="formatPng" />
           <label for="formatPng">PNG</label>
         </div>
       </fieldset>
@@ -33,11 +33,11 @@
       <fieldset id="shortcut">
         <legend>Enable shortcut (Shift+A)</legend>
         <div>
-          <input type="radio" name="shortcut" value="shortcutOff" />
+          <input type="radio" name="shortcut" id="shortcutOff" value="shortcutOff" />
           <label for="shortcutOff">Off</label>
         </div>
         <div>
-          <input type="radio" name="shortcut" value="shortcutOn" />
+          <input type="radio" name="shortcut" id="shortcutOn" value="shortcutOn" />
           <label for="shortcutOn">On</label>
         </div>
       </fieldset>
@@ -45,11 +45,11 @@
       <fieldset id="debug">
         <legend>Debug mode (for verbose logging in browser console)</legend>
         <div>
-          <input type="radio" name="debugMode" value="debugOff" />
+          <input type="radio" name="debugMode" id="debugOff" value="debugOff" />
           <label for="debugOff">Off</label>
         </div>
         <div>
-          <input type="radio" name="debugMode" value="debugOn" />
+          <input type="radio" name="debugMode" id="debugOn" value="debugOn" />
           <label for="debugOn">On</label>
         </div>
       </fieldset>

--- a/options/script.js
+++ b/options/script.js
@@ -3,13 +3,29 @@ const actionClipboardInput = document.querySelector("input[value=actionClipboard
 const formatFieldset = document.querySelector("fieldset#format");
 const formatPngInput = document.querySelector("input[value=formatPng]");
 
-function saveOptions(e) {
-  browser.storage.local.set({
+// Send message to active tabs to reload configuration
+async function sendReloadToTabs() {
+  const tabs = await browser.tabs.query({});
+
+  for (let tab of tabs) {
+    try {
+      await browser.tabs.sendMessage(tab.id, { cmd: "reloadConfiguration" });
+    } catch {
+      // Ignore
+    }
+  }
+}
+
+async function saveOptions(e) {
+  e.preventDefault();
+
+  await browser.storage.local.set({
     YouTubeScreenshotAddonisDebugModeOn: debugOnInput.checked,
     screenshotAction: actionClipboardInput.checked ? "clipboard" : "file",
     imageFormat: formatPngInput.checked ? "png" : "jpeg",
   });
-  e.preventDefault();
+
+  sendReloadToTabs();
 }
 
 function handleAction() {

--- a/options/script.js
+++ b/options/script.js
@@ -2,6 +2,7 @@ const debugOnInput = document.querySelector("input[value=debugOn]");
 const actionClipboardInput = document.querySelector("input[value=actionClipboard]");
 const formatFieldset = document.querySelector("fieldset#format");
 const formatPngInput = document.querySelector("input[value=formatPng]");
+const shortcutOffInput = document.querySelector("input[value=shortcutOff]");
 
 // Send message to active tabs to reload configuration
 async function sendReloadToTabs() {
@@ -23,6 +24,7 @@ async function saveOptions(e) {
     YouTubeScreenshotAddonisDebugModeOn: debugOnInput.checked,
     screenshotAction: actionClipboardInput.checked ? "clipboard" : "file",
     imageFormat: formatPngInput.checked ? "png" : "jpeg",
+    shortcutEnabled: !shortcutOffInput.checked,
   });
 
   sendReloadToTabs();
@@ -43,20 +45,29 @@ function restoreOptions() {
   });
 
   browser.storage.local.get().then((value) => {
+    // Debug mode
     if (value.YouTubeScreenshotAddonisDebugModeOn)
-    debugOnInput.checked = true;
+      debugOnInput.checked = true;
     else
-    document.querySelector("input[value=debugOff]").checked = true;
+      document.querySelector("input[value=debugOff]").checked = true;
 
+    // Screenshot action
     if (value.screenshotAction === "clipboard")
-    actionClipboardInput.checked = true;
+      actionClipboardInput.checked = true;
     else
-    document.querySelector("input[value=actionFile]").checked = true;
+      document.querySelector("input[value=actionFile]").checked = true;
 
+    // Image format
     if (value.imageFormat === "png")
-    formatPngInput.checked = true;
+      formatPngInput.checked = true;
     else
-    document.querySelector("input[value=formatJpeg]").checked = true;
+      document.querySelector("input[value=formatJpeg]").checked = true;
+
+    // Shortcut
+    if (value.shortcutEnabled === false)
+      shortcutOffInput.checked = true
+    else
+      document.querySelector("input[value=shortcutOn]").checked = true;
 
     handleAction();
   });


### PR DESCRIPTION
This PR replaces PR #32.

This PR mainly add hot reload mechanism when changing add-on preferences. It avoids to refresh the opened YouTube page to apply newly selected options. It works sending message from options script to tabs containing content script. The configuration is then reloaded when receiving such a message.

I have done some tests but of course should be validated by other users here.
Thanks.
