### PR TITLE
Add addon popup to edit preferences

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,11 @@
     "scripts": ["background.js"],
     "persistent": false
   },
+  "browser_action": {
+    "default_icon": "icons/icon.png",
+    "default_title": "YouTube Screenshot",
+    "default_popup": "options/index.html#popup"
+  },
   "options_ui": {
     "page": "options/index.html"
   },

--- a/options/script.js
+++ b/options/script.js
@@ -27,7 +27,12 @@ async function saveOptions(e) {
     shortcutEnabled: !shortcutOffInput.checked,
   });
 
-  sendReloadToTabs();
+  await sendReloadToTabs();
+
+  // In case the preferences are saved from popup,
+  // just close this window
+  if (location.hash === '#popup')
+    window.close();
 }
 
 function handleAction() {


### PR DESCRIPTION
Use exactly the same page for options and popup.
Only behavior change added is closing the popup when save button is clicked.

This PR addresses issue #23.