### PR TITLE
Download screenshot file in background script and add save as option

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,7 +17,8 @@ browser.runtime.onMessage.addListener(request => {
     browser.downloads.download({
       url: URL.createObjectURL(request.data),
       filename: request.filename,
-      conflictAction: "uniquify"
+      saveAs: request.saveAs,
+      conflictAction: "uniquify",
     })
     .then(() => { return Promise.resolve({}); })
     .catch((e) => { return Promise.resolve(e); });

--- a/background.js
+++ b/background.js
@@ -13,7 +13,15 @@ async function copyToClipboard(data) {
 }
 
 browser.runtime.onMessage.addListener(request => {
-  if (request.cmd === "copyToClipboard") {
+  if (request.cmd === "downloadFile") {
+    browser.downloads.download({
+      url: URL.createObjectURL(request.data),
+      filename: request.filename,
+      conflictAction: "uniquify"
+    })
+    .then(() => { return Promise.resolve({}); })
+    .catch((e) => { return Promise.resolve(e); });
+  } else if (request.cmd === "copyToClipboard") {
     copyToClipboard(request.data)
       .then(() => { return Promise.resolve({}); })
       .catch((e) => { return Promise.resolve(e); });

--- a/content_script.js
+++ b/content_script.js
@@ -50,17 +50,19 @@ captureScreenshot = function () {
 
   if (currentConfiguration.downloadFile)
     downloadFile(canvas, video);
-};
+}
 
 function downloadFile(canvas, video) {
-  let a = document.createElement("a");
-  a.href = canvas.toDataURL(`${currentConfiguration.imageFormat}`);
-  a.download = getFileName(video);
-  a.style.display = "none";
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-};
+  canvas.toBlob((blob) => {
+    browser.runtime.sendMessage({cmd: "downloadFile", data: blob, filename: getFileName(video)})
+      .then((e) => {
+        if (e)
+          logger(`Failed to download file: ${e.message}`);
+        else
+          logger("Successfully started download file");
+      });
+    }, currentConfiguration.imageFormat);
+}
 
 function copyToClipboard(canvas) {
   logger("Copying to clipboard");

--- a/content_script.js
+++ b/content_script.js
@@ -18,6 +18,7 @@ let currentConfiguration = {
   imageFormatExtension: "jpeg",
 
   shortcutEnabled: true,
+  saveAsEnabled: false,
 };
 
 // Shorts container tag and active attribute
@@ -54,7 +55,7 @@ captureScreenshot = function () {
 
 function downloadFile(canvas, video) {
   canvas.toBlob((blob) => {
-    browser.runtime.sendMessage({cmd: "downloadFile", data: blob, filename: getFileName(video)})
+    browser.runtime.sendMessage({cmd: "downloadFile", data: blob, filename: getFileName(video), saveAs: currentConfiguration.saveAsEnabled})
       .then((e) => {
         if (e)
           logger(`Failed to download file: ${e.message}`);
@@ -250,6 +251,10 @@ async function loadConfiguration() {
   // Shortcut
   currentConfiguration.shortcutEnabled = result.shortcutEnabled ?? true;
   logger(`${currentConfiguration.shortcutEnabled ? "Enabling" : "Disabling"} screenshot shortcut`);
+
+  // Save as
+  currentConfiguration.saveAsEnabled = result.saveAsEnabled ?? false;
+  logger(`${currentConfiguration.saveAsEnabled ? "Enabling" : "Disabling"} save as download`);
 
   // Button action and image format
   if (result.screenshotAction === "clipboard") {

--- a/manifest.json
+++ b/manifest.json
@@ -24,5 +24,5 @@
   "options_ui": {
     "page": "options/index.html"
   },
-  "permissions": ["storage", "clipboardWrite", "notifications"]
+  "permissions": ["storage", "downloads", "clipboardWrite", "notifications"]
 }

--- a/options/index.html
+++ b/options/index.html
@@ -46,6 +46,18 @@
         </div>
       </fieldset>
 
+      <fieldset id="saveAs">
+        <legend>Open file chooser dialog at download</legend>
+        <div>
+          <input type="radio" name="saveAs" id="saveAsOff" value="saveAsOff" />
+          <label for="saveAsOff">Off</label>
+        </div>
+        <div>
+          <input type="radio" name="saveAs" id="saveAsOn" value="saveAsOn" />
+          <label for="saveAsOn">On</label>
+        </div>
+      </fieldset>
+
       <fieldset id="debug">
         <legend>Debug mode (for verbose logging in browser console)</legend>
         <div>

--- a/options/script.js
+++ b/options/script.js
@@ -4,6 +4,7 @@ const actionBothInput = document.querySelector("input[value=actionBoth]");
 const formatFieldset = document.querySelector("fieldset#format");
 const formatPngInput = document.querySelector("input[value=formatPng]");
 const shortcutOffInput = document.querySelector("input[value=shortcutOff]");
+const saveAsOnInput = document.querySelector("input[value=saveAsOn]");
 
 // Send message to active tabs to reload configuration
 async function sendReloadToTabs() {
@@ -33,6 +34,7 @@ async function saveOptions(e) {
     screenshotAction: screenshotAction,
     imageFormat: formatPngInput.checked ? "png" : "jpeg",
     shortcutEnabled: !shortcutOffInput.checked,
+    saveAsEnabled: saveAsOnInput.checked,
   });
 
   await sendReloadToTabs();
@@ -83,6 +85,12 @@ function restoreOptions() {
       shortcutOffInput.checked = true
     else
       document.querySelector("input[value=shortcutOn]").checked = true;
+
+    // Save as
+    if (value.saveAsEnabled === true)
+      saveAsOnInput.checked = true
+    else
+      document.querySelector("input[value=saveAsOff]").checked = true;
 
     handleAction();
   });


### PR DESCRIPTION
Instead of adding an auto-clicked hyperlink containing screenshot data to
dowload it, pass the blob to background script and use browser.downloads
interface to do so.  It avoids memory leak as the browser does not really free
up the memory of the hyperlink even if removed from DOM.

Using browser.download() allows save as feature. Add a preference option to open
the file chooser dialog if enabled.

These commits addresses issues #58 and #59 from @probablytukars.