### PR TITLE
Fix promise returned by background script

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,22 +12,24 @@ async function copyToClipboard(data) {
   showNotification("Screenshot successfully copied to clipboard.");
 }
 
-browser.runtime.onMessage.addListener(request => {
-  if (request.cmd === "downloadFile") {
-    browser.downloads.download({
-      url: URL.createObjectURL(request.data),
-      filename: request.filename,
-      saveAs: request.saveAs,
-      conflictAction: "uniquify",
-    })
-    .then(() => { return Promise.resolve({}); })
-    .catch((e) => { return Promise.resolve(e); });
-  } else if (request.cmd === "copyToClipboard") {
-    copyToClipboard(request.data)
-      .then(() => { return Promise.resolve({}); })
-      .catch((e) => { return Promise.resolve(e); });
-  } else if (request.cmd === "showProtectionError") {
-    showNotification("Cannot screenshot DRM-protected content.");
-    return Promise.resolve({});
+browser.runtime.onMessage.addListener(async request => {
+  try {
+    if (request.cmd === "downloadFile") {
+      await browser.downloads.download({
+        url: URL.createObjectURL(request.data),
+        filename: request.filename,
+        saveAs: request.saveAs,
+        conflictAction: "uniquify",
+      });
+    } else if (request.cmd === "copyToClipboard") {
+      return copyToClipboard(request.data);
+    } else if (request.cmd === "showProtectionError") {
+      showNotification("Cannot screenshot DRM-protected content.");
+    }
+
+    // OK
+    return {};
+  } catch(e) {
+    throw e;
   }
 });

--- a/content_script.js
+++ b/content_script.js
@@ -56,12 +56,8 @@ captureScreenshot = function () {
 function downloadFile(canvas, video) {
   canvas.toBlob((blob) => {
     browser.runtime.sendMessage({cmd: "downloadFile", data: blob, filename: getFileName(video), saveAs: currentConfiguration.saveAsEnabled})
-      .then((e) => {
-        if (e)
-          logger(`Failed to download file: ${e.message}`);
-        else
-          logger("Successfully started download file");
-      });
+      .then(() => logger("Successfully started download file"))
+      .catch(e => logger(`Failed to download file: ${e.message}`))
     }, currentConfiguration.imageFormat);
 }
 
@@ -72,12 +68,8 @@ function copyToClipboard(canvas) {
     // Send the data to background script as navigator.clipboard.write()
     // is not yet supported by default on Firefox
     browser.runtime.sendMessage({cmd: "copyToClipboard", data: blob})
-      .then((e) => {
-        if (e)
-          logger(`Failed to copy to clipboad: ${e.message}`);
-        else
-          logger("Successfully copied to clipboard");
-      });
+      .then(() => logger("Successfully copied to clipboard"))
+      .catch(e => logger(`Failed to copy to clipboad: ${e.message}`))
     }, "image/png");
 }
 


### PR DESCRIPTION
Simplify browser.runtime.onMessage.addListener() handler promise return value using an async function first. Then, correctly use reject() / throw to return an error.
In the content script, now use .catch() method to retrieve error in a cleaner way.

---

This PR does not fix any "real" issue but will certainly better reveal several error. For example, now I got the following line when trying to download screenshot on several videos.
```
Youtube Screenshot Addon: Failed to download file: filename must not contain illegal characters
```
For information, issue is due to a pipe character in video title. An other PR soon to come (I hope). I think it is also related to issue #61.

Note: it may be interesting to add a notification for this error later.