### PR TITLE
Use browser style for action popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
   "browser_action": {
     "default_icon": "icons/icon.png",
     "default_title": "YouTube Screenshot",
-    "default_popup": "options/index.html#popup"
+    "default_popup": "options/index.html#popup",
+    "browser_style": true
   },
   "options_ui": {
     "page": "options/index.html"

--- a/options/script.js
+++ b/options/script.js
@@ -6,6 +6,9 @@ const formatPngInput = document.querySelector("input[value=formatPng]");
 const shortcutOffInput = document.querySelector("input[value=shortcutOff]");
 const saveAsOnInput = document.querySelector("input[value=saveAsOn]");
 
+function isPopup() {
+  return (location.hash === '#popup');
+}
 // Send message to active tabs to reload configuration
 async function sendReloadToTabs() {
   const tabs = await browser.tabs.query({});
@@ -41,7 +44,7 @@ async function saveOptions(e) {
 
   // In case the preferences are saved from popup,
   // just close this window
-  if (location.hash === '#popup')
+  if (isPopup())
     window.close();
 }
 
@@ -98,3 +101,8 @@ function restoreOptions() {
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.querySelector("#save").addEventListener("click", saveOptions);
+
+// Ensure padding for popup
+if (isPopup()) {
+  document.body.classList.add("popup");
+}

--- a/options/style.css
+++ b/options/style.css
@@ -1,3 +1,7 @@
+.popup {
+  padding: 8px;
+}
+
 .form {
   width: 100%;
 }


### PR DESCRIPTION
Simply set browser_style=true in Manifest.
Also add padding just in case of action popup, not in options page using the same HTML page.

Screenshot with patch:
The popup is better integrated with the rest of the Firefox UI.
<img width="2546" height="1470" alt="image" src="https://github.com/user-attachments/assets/2f8889ae-1c67-4a04-8fc6-9367f42b2d16" />

Current display:
<img width="861" height="850" alt="image" src="https://github.com/user-attachments/assets/32b548dc-0ada-4efb-8e37-cbeddc04ab3a" />
