### PR TITLE
Use browser style for action popup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,8 @@
   "browser_action": {
     "default_icon": "icons/icon.png",
     "default_title": "YouTube Screenshot",
-    "default_popup": "options/index.html#popup"
+    "default_popup": "options/index.html#popup",
+    "browser_style": true
   },
   "options_ui": {
     "page": "options/index.html"

--- a/options/script.js
+++ b/options/script.js
@@ -5,6 +5,9 @@ const formatFieldset = document.querySelector("fieldset#format");
 const formatPngInput = document.querySelector("input[value=formatPng]");
 const shortcutOffInput = document.querySelector("input[value=shortcutOff]");
 
+function isPopup() {
+  return (location.hash === '#popup');
+}
 // Send message to active tabs to reload configuration
 async function sendReloadToTabs() {
   const tabs = await browser.tabs.query({});
@@ -39,7 +42,7 @@ async function saveOptions(e) {
 
   // In case the preferences are saved from popup,
   // just close this window
-  if (location.hash === '#popup')
+  if (isPopup())
     window.close();
 }
 
@@ -90,3 +93,8 @@ function restoreOptions() {
 
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.querySelector("#save").addEventListener("click", saveOptions);
+
+// Ensure padding for popup
+if (isPopup()) {
+  document.body.classList.add("popup");
+}

--- a/options/style.css
+++ b/options/style.css
@@ -1,3 +1,7 @@
+.popup {
+  padding: 8px;
+}
+
 .form {
   width: 100%;
 }


### PR DESCRIPTION
Simply set browser_style=true in Manifest.
Also add padding just in case of action popup, not in options page using the same HTML page.

---

Report PR #77 on stable branch.