### PR TITLE
Use dedicated `commands` key to define screenshot shortcut

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -40,3 +40,17 @@ browser.runtime.onMessage.addListener(async request => {
     throw e;
   }
 });
+
+async function sendCommand(cmd)
+{
+  const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+  if (tabs.length > 0) {
+    browser.tabs.sendMessage(tabs[0].id, { cmd: cmd });
+  }
+}
+
+browser.commands.onCommand.addListener(cmd => {
+  if (cmd === "takeScreenshot") {
+    sendCommand(cmd);
+  }
+});

--- a/src/content_script.js
+++ b/src/content_script.js
@@ -322,36 +322,19 @@ loadConfiguration().then(() => {
 browser.runtime.onMessage.addListener(request => {
   logger("Received message from background script");
 
-  if (request.cmd === "reloadConfiguration")
+  if (request.cmd === "reloadConfiguration") {
     loadConfiguration();
+  } else if (request.cmd === "takeScreenshot") {
+    logger("Received takeScreenshot command from background");
 
-  return Promise.resolve({});
-});
-
-// Handle shortcut
-document.addEventListener('keydown', e => {
-  if (!currentConfiguration.shortcutEnabled) {
-    logger("Shortcut is disabled");
-    return;
-  }
-
-  const tagName = e.target.tagName;
-  if (e.target.isContentEditable
-      || (tagName === "INPUT")
-      || (tagName === "SELECT")
-      || (tagName === "TEXTAREA")) {
+    if (!currentConfiguration.shortcutEnabled) {
+      logger("Shortcut is disabled");
       return;
     }
 
-  if (!e.shiftKey)
-    return;
-
-  if ((e.key === 'a') || (e.key === 'A')) {
-    logger("Catching screenshot shortcut");
-
     // Simply search for the screenshot button and simulate click
-    let btn = document.querySelector("button.ytp-screenshot")
-              || document.querySelector("button.ytd-screenshot");
+    const btn = document.querySelector("button.ytp-screenshot")
+      || document.querySelector("button.ytd-screenshot");
 
     if (btn) {
       btn.click();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -27,6 +27,14 @@
     "page": "options/index.html"
   },
   "permissions": ["storage", "downloads", "clipboardWrite", "notifications"],
+  "commands": {
+    "takeScreenshot": {
+      "suggested_key": {
+        "default": "Alt+A"
+      },
+     "description": "Take a screenshot"
+    }
+  },
   "browser_specific_settings": {
     "gecko": {
       "data_collection_permissions": {

--- a/src/options/index.html
+++ b/src/options/index.html
@@ -35,7 +35,7 @@
       </fieldset>
 
       <fieldset id="shortcut">
-        <legend>Enable shortcut (Shift+A)</legend>
+        <legend>Enable shortcut</legend>
         <div>
           <input type="radio" name="shortcut" id="shortcutOff" value="shortcutOff" />
           <label for="shortcutOff">Off</label>


### PR DESCRIPTION
Replace the current manual keyboard listener and use dedicated mechanisme for add-ons.
Note that shortcut is expected to use a modifier so Shift+A is not a possible combination. Use Alt+A instead.
The shortcut can now also be customized from dedicated Firefox menu, see https://mzl.la/3Qwp5QQ